### PR TITLE
Add design documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,32 @@
+# ghctl
+
+The ghctl CLI tool for GitHub notifications, issue and pull-requests.
+
+<!-- markdown-toc start - Don't edit this section. Run M-x markdown-toc-refresh-toc -->
+**Table of Contents**
+
+- [ghctl](#ghctl)
+    - [Install](#install)
+    - [Usage](#usage)
+    - [Quick Starts](#quick-starts)
+    - [Complete documentation](#complete-documentation)
+
+<!-- markdown-toc end -->
+
+## Install
+
+// TBD
+
+## Usage
+
+```
+$ ghctl [command] [options...] [args...]
+```
+
+## Quick Starts
+
+// TBD
+
+## Complete documentation
+
+Plunge into the [commands](./cmd/README.md) or [packages](./pkg/README.md).

--- a/cmd/README.md
+++ b/cmd/README.md
@@ -1,0 +1,59 @@
+# Commands
+
+This package provides implementation of ghctl commands. ghctl is using
+[Cobra][0] for CLI framework.
+
+<!-- markdown-toc start - Don't edit this section. Run M-x markdown-toc-refresh-toc -->
+**Table of Contents**
+
+- [Commands](#commands)
+    - [Global](#global)
+        - [Commands](#commands-1)
+        - [Options](#options)
+    - [Authentication](#authentication)
+    - [Repository](#repository)
+    - [Issue](#issue)
+    - [Pull-request](#pull-request)
+    - [Notification](#notification)
+
+<!-- markdown-toc end -->
+
+## Global
+
+### Commands
+
+| COMMANDS         | SHORT NAME   | DESCRIPTION                           |
+| :--------------- | ------------ | :------------------------------------ |
+| authentication   | auth         | see [Authentication](#authentication) |
+| repository       | repo         | see [Repository](#repository)         |
+| issue            | -            | see [Issue](#issue)                   |
+| pull-request     | pr           | see [Pull-Request](#pull-request)     |
+| notification     | notif        | see [Notification](#notification)     |
+
+### Options
+
+| OPTIONS    | ARGS                | DESCRIPTION                                        |
+| :--------- | ------------------- | :------------------------------------------------- |
+| ghconfig   | filePath <string>   | Path to the configuration file to use for ghctl.   |
+
+## Authentication
+
+// TBD
+
+## Repository
+
+// TBD
+
+## Issue
+
+// TBD
+
+## Pull-request
+
+// TBD
+
+## Notification
+
+// TBD
+
+[0]: https://github.com/spf13/cobra

--- a/pkg/README.md
+++ b/pkg/README.md
@@ -1,0 +1,42 @@
+# Packages
+
+<!-- markdown-toc start - Don't edit this section. Run M-x markdown-toc-refresh-toc -->
+**Table of Contents**
+
+- [Packages](#packages)
+    - [Configuration](#configuration)
+        - [Configuration format](#configuration-format)
+        - [Directory architecture](#directory-architecture)
+
+<!-- markdown-toc end -->
+
+## Configuration
+
+`config` package manage configurations for ghctl.
+The configuration directory locates `$HOME/.ghctl/config` in default.
+If you set `--ghconfig`, ghctl use the path.
+
+### Configuration format
+
+The configuration file write in the YAML style.
+
+```yaml
+current-user: [name]
+users:
+  - name: <string>
+    token: <string>
+```
+
+### Directory architecture
+
+```bash
+❯❯❯ tree .ghctl/
+.ghctl/
+├── cache/
+└── config
+
+1 directory, 1 file
+```
+
+`.ghctl` contains configuration file and `cache` directory that stores
+ecache of repositories, issues and pull-requests.


### PR DESCRIPTION
Add some design documents for command, package and configuration.
Table of Contents are generated by `markdown-toc-generate-toc` command in Emacs.